### PR TITLE
Update for MediaWiki 1.38

### DIFF
--- a/csv-to-mysql.php
+++ b/csv-to-mysql.php
@@ -30,8 +30,8 @@ $host = '';
 $username = '';
 $password = '';
 
-$path_to_tables_file = '/path/to/tables-1.xx.txt';
-$path_to_schema_file = '/path/to/mediawiki-1.xx-schema-with-confirmacct.sql';
+$path_to_tables_file = '/path/to/tables-1.xx.txt'; # 1.xx: MediaWiki version of input DB
+$path_to_schema_file = '/path/to/mediawiki-1.yy-schema-with-confirmacct.sql'; # 1.yy: MediaWiki version for output DB
 
 $database = $argv[1];
 $csv_path = $argv[2];

--- a/csv-to-mysql.php
+++ b/csv-to-mysql.php
@@ -47,11 +47,10 @@ while (!feof($handle)) {
     `mysql -h ${host} -u ${username} -p${password} --local-infile=1 -e "SET foreign_key_checks = 0; LOAD DATA LOCAL INFILE '${csv_path}/${database}/${table}.csv' IGNORE INTO TABLE ${table} FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' ESCAPED BY '\"' LINES TERMINATED BY '\n' IGNORE 1 LINES (${l1});" ${database}`;
 }
 fclose($handle);
-`mysql -h ${host} -u ${username} -p${password} -e "UPDATE revision SET rev_content_format = NULL, rev_content_model = NULL WHERE rev_content_model = '';" ${database}`;
-`mysql -h ${host} -u ${username} -p${password} -e "UPDATE archive SET ar_content_format = NULL, ar_content_model = NULL WHERE ar_content_model = '';" ${database}`;
 `mysql -h ${host} -u ${username} -p${password} -e "UPDATE user SET user_password_expires = NULL WHERE user_password_expires REGEXP '[^A-Za-z0-9]';" ${database}`;
 `mysql -h ${host} -u ${username} -p${password} -e "UPDATE change_tag SET ct_params = NULL WHERE ct_params REGEXP '[^A-Za-z0-9]';" ${database}`;
 `mysql -h ${host} -u ${username} -p${password} -e "UPDATE user_groups SET ug_expiry = NULL WHERE ug_expiry REGEXP '[^A-Za-z0-9]';" ${database}`;
 `mysql -h ${host} -u ${username} -p${password} -e "UPDATE page SET page_lang = NULL WHERE page_lang REGEXP '[^A-Za-z]';" ${database}`;
 `mysql -h ${host} -u ${username} -p${password} -e "UPDATE updatelog SET ul_value = NULL WHERE ul_value REGEXP '[^A-Za-z]';" ${database}`;
 `mysql -h ${host} -u ${username} -p${password} -e "UPDATE watchlist SET wl_notificationtimestamp = NULL WHERE wl_notificationtimestamp REGEXP '[^A-Za-z0-9]';" ${database}`;
+`mysql -h ${host} -u ${username} -p${password} -e "UPDATE comment SET comment_data = NULL WHERE LENGTH(comment_data) = 0;" ${database}`;

--- a/csv-to-mysql.php
+++ b/csv-to-mysql.php
@@ -31,7 +31,7 @@ $username = '';
 $password = '';
 
 $path_to_tables_file = '/path/to/tables-1.xx.txt';
-$path_to_schema_file = '/path/to/mediawiki-1.31.0-schema-with-confirmacct.sql';
+$path_to_schema_file = '/path/to/mediawiki-1.xx-schema-with-confirmacct.sql';
 
 $database = $argv[1];
 $csv_path = $argv[2];

--- a/sqlite-to-csv.php
+++ b/sqlite-to-csv.php
@@ -25,8 +25,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-$sqlite_ext = '.sqlite';
-$path_to_tables_file = '/path/to/tables-1.35.txt';
+$sqlite_ext = 'sqlite';
+$path_to_tables_file = '/path/to/tables-1.xx.txt';
 
 $database = $argv[1];
 $sqlite_path = $argv[2];

--- a/sqlite-to-csv.php
+++ b/sqlite-to-csv.php
@@ -26,7 +26,7 @@
  */
 
 $sqlite_ext = 'sqlite';
-$path_to_tables_file = '/path/to/tables-1.xx.txt';
+$path_to_tables_file = '/path/to/tables-1.xx.txt'; # 1.xx: MediaWiki version of input DB
 
 $database = $argv[1];
 $sqlite_path = $argv[2];


### PR DESCRIPTION
The MySQL post-processing command in csv-to-mysql.php gave me a gew minor errors. Two SQL queries, which I discarded, referenced columns that were dropped from MW's DB schema. I added a query to fix values of the comment_data in the comment table.
I also removed two references to specific outdated MW versions.
In this form, the script worked for me when converting a MW 1.38 SQLite DB with almost no MW plugins installed to MySQL/MariaDB.